### PR TITLE
fix(RelyingParty): Throw correct error in logout() when no provider

### DIFF
--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -296,6 +296,7 @@ class RelyingParty extends JSONDocument {
   logout () {
     let configuration
     try {
+      assert(this.provider, 'OpenID Configuration is not initialized.')
       configuration = this.provider.configuration
       assert(configuration, 'OpenID Configuration is not initialized.')
       assert(configuration.end_session_endpoint,


### PR DESCRIPTION
Passes the 'should reject with missing OpenID Configuration' unit test for logout()
when no Provider has been initialized.