### PR TITLE
chore(npm): Switch npm 'main' to src/ instead of lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,14 @@
   "name": "@trust/oidc-rp",
   "version": "0.2.0",
   "description": "OpenID Connect Relying Party client library",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "files": [
-    "lib",
+    "src",
     "dist"
   ],
   "scripts": {
-    "build-lib": "babel src -d lib",
-    "build": "npm run clean-lib && npm run build-lib",
-    "clean-lib": "rm -rf lib/*",
-    "build-dist": "webpack --progress --colors --optimize-minimize",
-    "dist": "npm run build && npm run build-dist",
-    "prepublish": "npm run build && npm run build-dist",
+    "dist": "webpack --progress --colors --optimize-minimize",
+    "prepublish": "npm run dist",
     "test": "mocha -w"
   },
   "repository": {
@@ -47,7 +43,6 @@
     "@trust/webcrypto": "0.0.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path')
 
 module.exports = {
   entry: [
-    './lib/index.js'
+    './src/index.js'
   ],
   output: {
     path: path.join(__dirname, '/dist/'),


### PR DESCRIPTION
Webpack will auto-babelify at packaging time, so no need to publish it as ES5?