### PR TITLE
Concat url path properly to avoid double slash

### DIFF
--- a/src/RelyingParty.js
+++ b/src/RelyingParty.js
@@ -3,6 +3,7 @@
  */
 const assert = require('assert')
 const fetch = require('node-fetch')
+const URL = require('urlutils')
 const Headers = fetch.Headers ? fetch.Headers : global.Headers
 const {JSONSchema, JSONDocument} = require('@trust/json-document')
 const {JWKSet} = require('@trust/jose')
@@ -141,11 +142,13 @@ class RelyingParty extends JSONDocument {
   discover () {
     try {
       let issuer = this.provider.url
-      let endpoint = '.well-known/openid-configuration'
 
       assert(issuer, 'RelyingParty provider must define "url"')
 
-      return fetch(`${issuer}/${endpoint}`)
+      let url = new URL(issuer)
+      url.pathname = '.well-known/openid-configuration'
+
+      return fetch(url.toString())
         //.then(status(200))
         .then(response => {
           return response.json().then(json => this.provider.configuration = json)


### PR DESCRIPTION
Ideally this would have a test, but there are no tests in that module that hit the (fake) network. I'd rather let you folks take the first step in how you want to set up your network mocks.
