### PR TITLE
fix(RelyingParty): Reject fetch operations on http error codes

### DIFF
--- a/src/AuthenticationResponse.js
+++ b/src/AuthenticationResponse.js
@@ -9,7 +9,7 @@ const fetch = require('node-fetch')
 const Headers = fetch.Headers ? fetch.Headers : global.Headers
 const FormUrlEncoded = require('./FormUrlEncoded')
 const IDToken = require('./IDToken')
-//const AccessToken = require('./AccessToken')
+const onHttpError = require('./onHttpError')
 
 /**
  * AuthenticationResponse
@@ -262,6 +262,7 @@ class AuthenticationResponse {
     // make the token request
 
     return fetch(endpoint, {method, headers, body})
+      .then(onHttpError('Error exchanging authorization code'))
       .then(tokenResponse => tokenResponse.json())
       .then(tokenResponse => {
         assert(tokenResponse['access_token'],

--- a/src/onHttpError.js
+++ b/src/onHttpError.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * Throws an error when a fetch response status code indicates a 400 or 500
+ * HTTP error. (The whatwg fetch api does not normally reject on http error
+ * responses).
+ *
+ * Usage:
+ *
+ * ```
+ * return fetch(url)
+ *   .then(onHttpError('Error while fetching resource')
+ *   .catch(err => console.log(err))
+ *
+ * // -> 'Error while fetching resource: 404 Not Found' error
+ * // if a 404 response is encountered
+ * ```
+ *
+ * @param [message] {string} Optional error message to clarify context
+ *
+ * @throws {Error} For http status codes > 300
+ *
+ * @return {Object} fetch response object (passed through if no error)
+ */
+function onHttpError (message = 'fetch error') {
+  return (response) => {
+    if (response.status >= 200 && response.status < 300) {
+      return response
+    }
+
+    let errorMessage = `${message}: ${response.status} ${response.statusText}`
+    let error = new Error(errorMessage)
+    error.response = response
+    error.statusCode = response.status
+    throw error
+  }
+}
+
+module.exports = onHttpError

--- a/test/AuthenticationResponseSpec.js
+++ b/test/AuthenticationResponseSpec.js
@@ -428,6 +428,22 @@ describe('AuthenticationResponse', () => {
     it('should include token response in response params')
 
     it('should return its argument')
+
+    it('should reject on an http error', done => {
+      let providerUrl = 'https://notfound'
+
+      nock(providerUrl).post('/token').reply(404)
+
+      response.rp.provider.configuration.url = providerUrl
+      response.rp.provider.configuration['token_endpoint'] = providerUrl + '/token'
+
+      AuthenticationResponse.exchangeAuthorizationCode(response)
+        .catch(err => {
+          expect(err.message)
+            .to.match(/Error exchanging authorization code: 404 Not Found/)
+          done()
+        })
+    })
   })
 
   /**

--- a/test/onHttpErrorSpec.js
+++ b/test/onHttpErrorSpec.js
@@ -1,0 +1,72 @@
+'use strict'
+
+/**
+ * Test dependencies
+ */
+const chai = require('chai')
+
+/**
+ * Assertions
+ */
+chai.should()
+chai.use(require('chai-as-promised'))
+chai.use(require('dirty-chai'))
+let expect = chai.expect
+
+/**
+ * Code under test
+ */
+const onHttpError = require('../src/onHttpError')
+
+describe('onHttpError', () => {
+  it('should pass through the response with status code < 300', () => {
+    let response = { status: 200 }
+    let errorHandler = onHttpError()
+
+    expect(errorHandler(response)).to.equal(response)
+  })
+
+  it('should throw an error on http error response', () => {
+    let response = { status: 400, statusText: 'Bad Request' }
+
+    let errorHandler = onHttpError('Error during some operation')
+
+    expect(() => errorHandler(response))
+      .to.throw(/Error during some operation: 400 Bad Request/)
+  })
+
+  it('should set a default error message', () => {
+    let response = { status: 404, statusText: 'Not Found' }
+
+    let errorHandler = onHttpError()
+
+    expect(() => errorHandler(response))
+      .to.throw(/fetch error: 404 Not Found/)
+  })
+
+  it('should pass through the status code to the error', done => {
+    let response = { status: 400, statusText: 'Bad Request' }
+
+    let errorHandler = onHttpError()
+
+    try {
+      errorHandler(response)
+    } catch (err) {
+      expect(err.statusCode).to.equal(400)
+      done()
+    }
+  })
+
+  it('should set the response object on the error', done => {
+    let response = { status: 500, statusText: 'Internal Server Error' }
+
+    let errorHandler = onHttpError()
+
+    try {
+      errorHandler(response)
+    } catch (err) {
+      expect(err.response).to.equal(response)
+      done()
+    }
+  })
+})


### PR DESCRIPTION
Addresses issue #26.

Implement an `onHttpError()` handler, reject `fetch()` operations when encountering
http error status codes.