### PR TITLE
Throw when query and fragment are both missing

### DIFF
--- a/src/AuthenticationResponse.js
+++ b/src/AuthenticationResponse.js
@@ -61,7 +61,7 @@ class AuthenticationResponse {
       let url = new URL(redirect)
       let {search, hash} = url
 
-      if (search && hash) {
+      if ((search && hash) || (!search && !hash)) {
         throw new Error('Invalid response mode')
       }
 

--- a/test/AuthenticationResponseSpec.js
+++ b/test/AuthenticationResponseSpec.js
@@ -56,6 +56,14 @@ describe('AuthenticationResponse', () => {
       }).to.throw('Invalid response mode')
     })
 
+    it('should throw without query and fragment', () => {
+      expect(() => {
+        AuthenticationResponse.parseResponse({
+          redirect: 'https://example.com/callback'
+        })
+      }).to.throw('Invalid response mode')
+    })
+
     it('should parse query response', () => {
       let response = { redirect: 'https://example.com/callback?code=1234' }
       AuthenticationResponse.parseResponse(response)


### PR DESCRIPTION
When query and fragment are both missing, `params` remains unset, leading `matchRequest` to error.