### PR TITLE
Babel transpile on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/anvilresearch/oidc-rp#readme",
   "dependencies": {
     "base64url": "^2.0.0",
-    "@trust/jose": "^0.1.2",
+    "@trust/jose": "^0.1.6",
     "@trust/json-document": "^0.1.4",
     "node-fetch": "^1.7.1",
     "text-encoding": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.3.1",
   "description": "OpenID Connect Relying Party client library",
   "main": "./lib/index.js",
+  "module": "./src/index.js",
   "files": [
     "lib",
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "babel src -d lib",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-fetch": "^1.7.1",
     "text-encoding": "^0.6.1",
     "urlutils": "0.0.3",
-    "@trust/webcrypto": "0.0.2"
+    "@trust/webcrypto": "0.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "@trust/oidc-rp",
   "version": "0.3.1",
   "description": "OpenID Connect Relying Party client library",
-  "main": "src/index.js",
+  "main": "./lib/index.js",
   "files": [
-    "src",
+    "lib",
     "dist"
   ],
   "scripts": {
+    "build": "babel src -d lib",
     "dist": "webpack --progress --colors --optimize-minimize",
-    "prepublish": "npm run dist",
+    "prepublish": "npm run build && npm run dist && npm run test",
+    "preversion": "npm test",
     "test": "mocha"
   },
   "repository": {
@@ -43,12 +45,13 @@
     "@trust/webcrypto": "0.0.2"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^4.0.2",
-    "chai-as-promised": "^6.0.0",
-    "dirty-chai": "^1.2.2",
+    "chai-as-promised": "^7.1.1",
+    "dirty-chai": "^2.0.1",
     "mocha": "^3.2.0",
     "nock": "^9.0.13",
     "sinon": "^2.3.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
+        exclude: /(node_modules)/,
         loader: 'babel-loader',
         query: {
           presets: ['es2015']


### PR DESCRIPTION
Make downstream usage easier. Addresses issue #30.
Also bumps @trust/webcrypto dep to 0.3.0.